### PR TITLE
fix: checkbox placement for enabling low-latency HLS Streaming CMAF

### DIFF
--- a/src/app/app.page/app.page.component.html
+++ b/src/app/app.page/app.page.component.html
@@ -1304,6 +1304,23 @@
 
                                                             </div>
                                                         </div>
+                                                        
+                                                        <div class="form-group">
+                                                            <div class="col-sm-12 col-md-12 text-left">
+                                                                <div class="checkbox">
+
+                                                                    <input [(ngModel)]="appSettings.lLHLSEnabled"
+                                                                        id="lLHLSEnabled" name="lLHLSEnabled"
+                                                                        type="checkbox">
+
+                                                                    <label for="lLHLSEnabled"
+                                                                        i18n="@@lLHLSEnabled">
+                                                                        Enable Low Latency HLS Streaming(CMAF)
+                                                                    </label>
+
+                                                                </div>
+                                                            </div>
+                                                        </div>
 
                                                         <div class="form-group">
                                                             <div class="col-sm-12 col-md-12 text-left">
@@ -1420,23 +1437,6 @@
                                                                     <label for="lLDashEnabled"
                                                                         i18n="@@lLDashEnabled">
                                                                         Enable Low Latency DASH Streaming(CMAF)
-                                                                    </label>
-
-                                                                </div>
-                                                            </div>
-                                                        </div>
-
-                                                        <div class="form-group">
-                                                            <div class="col-sm-12 col-md-12 text-left">
-                                                                <div class="checkbox">
-
-                                                                    <input [(ngModel)]="appSettings.lLHLSEnabled"
-                                                                        id="lLHLSEnabled" name="lLHLSEnabled"
-                                                                        type="checkbox">
-
-                                                                    <label for="lLHLSEnabled"
-                                                                        i18n="@@lLHLSEnabled">
-                                                                        Enable Low Latency HLS Streaming(CMAF)
                                                                     </label>
 
                                                                 </div>


### PR DESCRIPTION
Fixed checkbox placement for, enabling low-latency HLS Streaming CMAF to streamline with HLS Streaming section.

Ref: https://github.com/ant-media/Ant-Media-Server/issues/4743